### PR TITLE
Update build-openwrt1.yml

### DIFF
--- a/.github/workflows/build-openwrt.yml
+++ b/.github/workflows/build-openwrt.yml
@@ -8,7 +8,7 @@
 # Description: Build OpenWrt using GitHub Actions
 #
 
-name: Build xwrt
+name: Build openwrt
 
 on:
   repository_dispatch:
@@ -20,7 +20,7 @@ on:
         default: 'false'
 
 env:
-  REPO_URL: https://github.com/x-wrt/x-wrt
+  REPO_URL: https://github.com/Boos4721/openwrt
   REPO_BRANCH: master
   FEEDS_CONF: feeds.conf.default
   CONFIG_FILE: .config
@@ -36,7 +36,8 @@ env:
   UPLOAD_COWTRANSFER: false
   UPLOAD_WETRANSFER: false
   UPLOAD_RELEASE: true
-  TZ: Europe/Moscow
+  TZ: Asia/Ho_Chi_Minh
+ 
 
 jobs:
   build:
@@ -63,47 +64,47 @@ jobs:
       working-directory: /workdir
       run: |
         df -hT $PWD
-        git clone $REPO_URL -b $REPO_BRANCH xwrt
-        ln -sf /workdir/xwrt $GITHUB_WORKSPACE/xwrt
+        git clone $REPO_URL -b $REPO_BRANCH openwrt
+        ln -sf /workdir/openwrt $GITHUB_WORKSPACE/openwrt
 
     - name: Load custom feeds
       run: |
-        [ -e $FEEDS_CONF ] && mv $FEEDS_CONF xwrt/feeds.conf.default
+        [ -e $FEEDS_CONF ] && mv $FEEDS_CONF openwrt/feeds.conf.default
         chmod +x $DIY_P1_SH
-        cd xwrt
+        cd openwrt
         $GITHUB_WORKSPACE/$DIY_P1_SH
 
     - name: Update feeds
-      run: cd xwrt && ./scripts/feeds update -a
+      run: cd openwrt && ./scripts/feeds update -a
 
     - name: Install feeds
-      run: cd xwrt && ./scripts/feeds install -a
+      run: cd openwrt && ./scripts/feeds install -a
 
     - name: Load custom configuration
       env:
         check: 0
       run: |
-        [ -e files ] && mv files xwrt/files
+        [ -e files ] && mv files openwrt/files
         if [ -e $CONFIG_FILE ];
-        then mv $CONFIG_FILE xwrt/.config;
+        then mv $CONFIG_FILE openwrt/.config;
              echo "Use .config from repo";
         else if [ ! -z "$ALT_CONFIG_URL" ];
-             then curl -Lo xwrt/.config $ALT_CONFIG_URL;
+             then curl -Lo openwrt/.config $ALT_CONFIG_URL;
                   echo "successfully download .config from url, .config in repo don't exist";
                   echo "checking .config";
-                  check=$(grep -e "^# Automatically generated file; DO NOT EDIT.$" xwrt/.config && grep -e "^# OpenWrt Configuration$" xwrt/.config);
+                  check=$(grep -e "^# Automatically generated file; DO NOT EDIT.$" openwrt/.config && grep -e "^# OpenWrt Configuration$" openwrt/.config);
                   if [ ! "$(echo $check |wc -c)" = "69" ];
                   then echo ".config invalid, setting default for mt7620";
-                       rm -rf xwrt/.config;
-                       cp xwrt/feeds/x/rom/lede/config.ramips-mt7620 xwrt/.config;
+                       rm -rf openwrt/.config;
+                       cp openwrt/feeds/x/rom/lede/config.ramips-mt7620 openwrt/.config;
                   else echo "naive check passed";
                   fi
-             else cp xwrt/feeds/x/rom/lede/config.ramips-mt7620 xwrt/.config;
-                  echo "use default .config for mt7620 in xwrt, url not set and .config in repo don't exist";
+             else cp openwrt/feeds/x/rom/lede/config.ramips-mt7620 openwrt/.config;
+                  echo "use default .config for mt7620 in openwrt, url not set and .config in repo don't exist";
              fi
         fi
         chmod +x $DIY_P2_SH
-        cd xwrt
+        cd openwrt
         $GITHUB_WORKSPACE/$DIY_P2_SH
 
     - name: SSH connection to Actions
@@ -116,7 +117,7 @@ jobs:
     - name: Download package
       id: package
       run: |
-        cd xwrt
+        cd openwrt
         make defconfig
         make download -j8
         find dl -size -1024c -exec ls -l {} \;
@@ -125,7 +126,7 @@ jobs:
     - name: Compile the firmware
       id: compile
       run: |
-        cd xwrt
+        cd openwrt
         echo -e "$(nproc) thread compile"
         make -j$(nproc) || make -j1 || make -j1 V=s
         echo "status=success" >> $GITHUB_OUTPUT
@@ -141,14 +142,14 @@ jobs:
       uses: actions/upload-artifact@main
       if: steps.compile.outputs.status == 'success' && env.UPLOAD_BIN_DIR == 'true'
       with:
-        name: xwrt_bin${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
-        path: xwrt/bin
+        name: openwrt_bin${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
+        path: openwrt/bin
 
     - name: Organize files
       id: organize
       if: env.UPLOAD_FIRMWARE == 'true' && !cancelled()
       run: |
-        cd xwrt/bin/targets/*/*
+        cd openwrt/bin/targets/*/*
         rm -rf packages
         echo "FIRMWARE=$PWD" >> $GITHUB_ENV
         echo "status=success" >> $GITHUB_OUTPUT
@@ -157,7 +158,7 @@ jobs:
       uses: actions/upload-artifact@main
       if: steps.organize.outputs.status == 'success' && !cancelled()
       with:
-        name: xwrt_firmware${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
+        name: openwrt_firmware${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
         path: ${{ env.FIRMWARE }}
 
     - name: Upload firmware to cowtransfer


### PR DESCRIPTION
#
# Copyright (c) 2019-2020 P3TERX <https://p3terx.com>
#
# This is free software, licensed under the MIT License.
# See /LICENSE for more information.
#
# https://github.com/P3TERX/Actions-OpenWrt
# Description: Build OpenWrt using GitHub Actions
#

name: Build openwrt

on:
  repository_dispatch:
  workflow_dispatch:
    inputs:
      ssh:
        description: 'SSH connection to Actions'
        required: false
        default: 'false'

env:
  REPO_URL: https://github.com/Boos4721/openwrt
  REPO_BRANCH: master
  FEEDS_CONF: feeds.conf.default
  CONFIG_FILE: .config
  DIY_P1_SH: diy-part1.sh
  DIY_P2_SH: diy-part2.sh
  #by default used .config for build from repo
  #if your repo not contain .config, you may download it from direct url setting by ALT_CONFIG_URL variable
  #if ALT_CONFIG_URL commented and repo not contain .config - use default for mt7620
  #.config from repo > .config from url > default .config
  ALT_CONFIG_URL: false
  UPLOAD_BIN_DIR: false
  UPLOAD_FIRMWARE: true
  UPLOAD_COWTRANSFER: false
  UPLOAD_WETRANSFER: false
  UPLOAD_RELEASE: true
  TZ: Asia/Ho_Chi_Minh
 

jobs:
  build:
    runs-on: ubuntu-22.04

    steps:
    - name: Checkout
      uses: actions/checkout@main

    - name: Initialization environment
      env:
        DEBIAN_FRONTEND: noninteractive
      run: |
        sudo rm -rf /etc/apt/sources.list.d/* /usr/share/dotnet /usr/local/lib/android /opt/ghc
        sudo -E apt-get -qq update
        sudo -E apt-get -qq install build-essential clang flex g++ gawk gcc-multilib gettext git libncurses5-dev libssl-dev python3-distutils rsync unzip zlib1g-dev file wget
        sudo -E apt-get -qq autoremove --purge
        sudo -E apt-get -qq clean
        sudo timedatectl set-timezone "$TZ"
        sudo mkdir -p /workdir
        sudo chown $USER:$GROUPS /workdir

    - name: Clone source code
      working-directory: /workdir
      run: |
        df -hT $PWD
        git clone $REPO_URL -b $REPO_BRANCH openwrt
        ln -sf /workdir/openwrt $GITHUB_WORKSPACE/openwrt

    - name: Load custom feeds
      run: |
        [ -e $FEEDS_CONF ] && mv $FEEDS_CONF openwrt/feeds.conf.default
        chmod +x $DIY_P1_SH
        cd openwrt
        $GITHUB_WORKSPACE/$DIY_P1_SH

    - name: Update feeds
      run: cd openwrt && ./scripts/feeds update -a

    - name: Install feeds
      run: cd openwrt && ./scripts/feeds install -a

    - name: Load custom configuration
      env:
        check: 0
      run: |
        [ -e files ] && mv files openwrt/files
        if [ -e $CONFIG_FILE ];
        then mv $CONFIG_FILE openwrt/.config;
             echo "Use .config from repo";
        else if [ ! -z "$ALT_CONFIG_URL" ];
             then curl -Lo openwrt/.config $ALT_CONFIG_URL;
                  echo "successfully download .config from url, .config in repo don't exist";
                  echo "checking .config";
                  check=$(grep -e "^# Automatically generated file; DO NOT EDIT.$" openwrt/.config && grep -e "^# OpenWrt Configuration$" openwrt/.config);
                  if [ ! "$(echo $check |wc -c)" = "69" ];
                  then echo ".config invalid, setting default for mt7620";
                       rm -rf openwrt/.config;
                       cp openwrt/feeds/x/rom/lede/config.ramips-mt7620 openwrt/.config;
                  else echo "naive check passed";
                  fi
             else cp openwrt/feeds/x/rom/lede/config.ramips-mt7620 openwrt/.config;
                  echo "use default .config for mt7620 in openwrt, url not set and .config in repo don't exist";
             fi
        fi
        chmod +x $DIY_P2_SH
        cd openwrt
        $GITHUB_WORKSPACE/$DIY_P2_SH

    - name: SSH connection to Actions
      uses: P3TERX/ssh2actions@v1.0.0
      if: (github.event.inputs.ssh == 'true' && github.event.inputs.ssh  != 'false') || contains(github.event.action, 'ssh')
      env:
        TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
        TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

    - name: Download package
      id: package
      run: |
        cd openwrt
        make defconfig
        make download -j8
        find dl -size -1024c -exec ls -l {} \;
        find dl -size -1024c -exec rm -f {} \;

    - name: Compile the firmware
      id: compile
      run: |
        cd openwrt
        echo -e "$(nproc) thread compile"
        make -j$(nproc) || make -j1 || make -j1 V=s
        echo "status=success" >> $GITHUB_OUTPUT
        grep '^CONFIG_TARGET.*DEVICE.*=y' .config | sed -r 's/.*DEVICE_(.*)=y/\1/' > DEVICE_NAME
        [ -s DEVICE_NAME ] && echo "DEVICE_NAME=_$(cat DEVICE_NAME)" >> $GITHUB_ENV
        echo "FILE_DATE=_$(date +"%Y%m%d%H%M")" >> $GITHUB_ENV

    - name: Check space usage
      if: (!cancelled())
      run: df -hT

    - name: Upload bin directory
      uses: actions/upload-artifact@main
      if: steps.compile.outputs.status == 'success' && env.UPLOAD_BIN_DIR == 'true'
      with:
        name: openwrt_bin${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
        path: openwrt/bin

    - name: Organize files
      id: organize
      if: env.UPLOAD_FIRMWARE == 'true' && !cancelled()
      run: |
        cd openwrt/bin/targets/*/*
        rm -rf packages
        echo "FIRMWARE=$PWD" >> $GITHUB_ENV
        echo "status=success" >> $GITHUB_OUTPUT

    - name: Upload firmware directory
      uses: actions/upload-artifact@main
      if: steps.organize.outputs.status == 'success' && !cancelled()
      with:
        name: openwrt_firmware${{ env.DEVICE_NAME }}${{ env.FILE_DATE }}
        path: ${{ env.FIRMWARE }}

    - name: Upload firmware to cowtransfer
      id: cowtransfer
      if: steps.organize.outputs.status == 'success' && env.UPLOAD_COWTRANSFER == 'true' && !cancelled()
      run: |
        curl -fsSL git.io/file-transfer | sh
        ./transfer cow --block 2621440 -s -p 64 --no-progress ${FIRMWARE} 2>&1 | tee cowtransfer.log
        echo "::warning file=cowtransfer.com::$(cat cowtransfer.log | grep https)"
        echo "url=$(cat cowtransfer.log | grep https | cut -f3 -d" ")" >> $GITHUB_OUTPUT

    - name: Upload firmware to WeTransfer
      id: wetransfer
      if: steps.organize.outputs.status == 'success' && env.UPLOAD_WETRANSFER == 'true' && !cancelled()
      run: |
        curl -fsSL git.io/file-transfer | sh
        ./transfer wet -s -p 16 --no-progress ${FIRMWARE} 2>&1 | tee wetransfer.log
        echo "::warning file=wetransfer.com::$(cat wetransfer.log | grep https)"
        echo "url=$(cat wetransfer.log | grep https | cut -f3 -d" ")" >> $GITHUB_OUTPUT

    - name: Generate release tag
      id: tag
      if: env.UPLOAD_RELEASE == 'true' && !cancelled()
      run: |
        echo "release_tag=$(date +"%Y.%m.%d-%H%M")" >> $GITHUB_OUTPUT
        touch release.txt
        [ $UPLOAD_COWTRANSFER = true ] && echo "🔗 [Cowtransfer](${{ steps.cowtransfer.outputs.url }})" >> release.txt
        [ $UPLOAD_WETRANSFER = true ] && echo "🔗 [WeTransfer](${{ steps.wetransfer.outputs.url }})" >> release.txt
        echo "status=success" >> $GITHUB_OUTPUT

    - name: Upload firmware to release
      uses: softprops/action-gh-release@v1
      if: steps.tag.outputs.status == 'success' && !cancelled()
      env:
        GITHUB_TOKEN: ${{ secrets.ACTIONS_TRIGGER_PAT }}
      with:
        tag_name: ${{ steps.tag.outputs.release_tag }}
        body_path: release.txt
        files: ${{ env.FIRMWARE }}/*

    - name: Delete workflow runs
      uses: astolfogit/delete-workflow-runs@main
      with:
        retain_days: 1
        keep_minimum_runs: 3

    - name: Remove old Releases
      uses: dev-drprasad/delete-older-releases@v0.2.1
      if: env.UPLOAD_RELEASE == 'true' && !cancelled()
      with:
        keep_latest: 3
        delete_tags: true
      env:
        GITHUB_TOKEN: ${{ secrets.ACTIONS_TRIGGER_PAT }}

